### PR TITLE
fix: ban wallet from delegation

### DIFF
--- a/contracts/core/SettingsManager.sol
+++ b/contracts/core/SettingsManager.sol
@@ -122,13 +122,13 @@ contract SettingsManager is ISettingsManager, Ownable, Constants {
         }
     }
 
-    function addDelegatesToBlackList(address[] memory _delegates) external {
+    function addDelegatesToBanList(address[] memory _delegates) external {
         require(operators.getOperatorLevel(msg.sender) >= uint8(1), "Invalid operator");
         for (uint256 i = 0; i < _delegates.length; ++i) {
             EnumerableSet.add(banWalletList, _delegates[i]);
         }
     }
-    function removeDelegatesFromBlackList(address[] memory _delegates) external {
+    function removeDelegatesFromBanList(address[] memory _delegates) external {
         require(operators.getOperatorLevel(msg.sender) >= uint8(1), "Invalid operator");
         for (uint256 i = 0; i < _delegates.length; ++i) {
             EnumerableSet.remove(banWalletList, _delegates[i]);
@@ -486,6 +486,7 @@ contract SettingsManager is ISettingsManager, Ownable, Constants {
     }
 
     function checkDelegation(address _master, address _delegate) public view override returns (bool) {
+        require(!checkBanList(_master), "prevent banners from delegation");
         return _master == _delegate || EnumerableSet.contains(_delegatesByMaster[_master], _delegate);
     }
 

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -106,13 +106,13 @@ contract Vault is Constants, ReentrancyGuard, Ownable, IVault {
         address _indexToken,
         uint256 _sizeDelta,
         uint256 _posId
-    ) payable external nonReentrant preventTradeForForexCloseTime(_indexToken) preventBanners (msg.sender) {
+    ) payable external nonReentrant preventTradeForForexCloseTime(_indexToken) preventBanners(msg.sender) {
         require(msg.value == settingsManager.globalGasFee(), "invalid globalGasFee");
         payable(settingsManager.feeManager()).transfer(msg.value);
         positionVault.decreasePosition(msg.sender, _indexToken, _sizeDelta, _posId);
     }
 
-    function deposit(address _account, address _token, uint256 _amount) external nonReentrant preventBanners (msg.sender) {
+    function deposit(address _account, address _token, uint256 _amount) external nonReentrant preventBanners(msg.sender) {
         uint256 collateralDeltaUsd = priceManager.tokenToUsd(_token, _amount);
         require(settingsManager.isDeposit(_token), "deposit not allowed");
         require(_amount > 0, "zero amount");
@@ -141,7 +141,7 @@ contract Vault is Constants, ReentrancyGuard, Ownable, IVault {
         OrderType _orderType,
         uint256[] memory _params,
         address _refer
-    ) external payable nonReentrant preventBanners (msg.sender) preventTradeForForexCloseTime(_indexToken) {
+    ) external payable nonReentrant preventBanners(msg.sender) preventTradeForForexCloseTime(_indexToken) {
         if (_orderType != OrderType.MARKET) {
             require(msg.value == settingsManager.triggerGasFee(), "invalid triggerGasFee");
             payable(settingsManager.feeManager()).transfer(msg.value);

--- a/test/core/Vault.js
+++ b/test/core/Vault.js
@@ -2243,7 +2243,7 @@ describe("Vault", function () {
     const slippage = 1000 // 1%
     const collateral = amountIn;
     const size = toUsdAmount;
-    await settingsManager.addDelegatesToBlackList([wallet.address])
+    await settingsManager.addDelegatesToBanList([wallet.address])
     await expect(Vault.connect(wallet).newPositionOrder(
       btc.address, //_indexToken
       isLong,
@@ -2256,7 +2256,7 @@ describe("Vault", function () {
        ], //triggerPrices
       referAddress
     )).to.be.revertedWith("prevent banners from trade, stake, deposit")
-    await settingsManager.removeDelegatesFromBlackList([wallet.address])
+    await settingsManager.removeDelegatesFromBanList([wallet.address])
     await Vault.connect(wallet).newPositionOrder(
       btc.address, //_indexToken
       isLong,
@@ -2269,5 +2269,17 @@ describe("Vault", function () {
        ], //triggerPrices
       referAddress
     )
+  })
+
+  it ("checkBanWallet delegation", async() =>{
+    const amount = expandDecimals('1000', 18)
+    await settingsManager.addDelegatesToBanList([wallet.address])
+    await expect(Vault.connect(wallet).stake(
+      wallet.address, usdc.address, amount
+    )).to.be.revertedWith("prevent banners from trade, stake, deposit")
+    await settingsManager.connect(wallet).delegate([user2.address])
+    await expect(Vault.connect(user2).stake(
+      wallet.address, usdc.address, amount
+    )).to.be.revertedWith("prevent banners from delegation")
   })
 });


### PR DESCRIPTION
wallets being banned should not pass `checkDelegation` check