### PR TITLE
oracle: allow set timestamp for price

### DIFF
--- a/contracts/core/PositionVault.sol
+++ b/contracts/core/PositionVault.sol
@@ -382,14 +382,10 @@ contract PositionVault is Constants, ReentrancyGuard, IPositionVault {
         openMarketQueueIndex = index;
     }
 
-    function executeOpenMarketOrdersWithPrices(
-        uint256 numOfOrders,
-        address[] calldata indexTokens,
-        uint256[] calldata prices
+    function executeOpenMarketOrders(
+        uint256 numOfOrders
     ) external {
         require(settingsManager.isManager(msg.sender), "You are not allowed to trigger");
-
-        priceManager.setLatestPrices(indexTokens, prices);
         _executeOpenMarketOrders(numOfOrders);
     }
 

--- a/contracts/core/PriceManager.sol
+++ b/contracts/core/PriceManager.sol
@@ -64,7 +64,7 @@ contract PriceManager is IPriceManager, Ownable, Constants {
 
         IPriceFeed priceFeed = IPriceFeed(priceFeedAddress);
 
-        uint256 price = priceFeed.latestAnswer();
+        uint256 price = priceFeed.latestAnswer(_token);
         require(price > 0, "VaultPriceFeed: could not fetch price");
         uint256 _priceDecimals = priceDecimals[_token];
         return (price * PRICE_PRECISION) / (10 ** _priceDecimals);
@@ -77,7 +77,7 @@ contract PriceManager is IPriceManager, Ownable, Constants {
 
         // TODO: verify the price against pyth oracle before setting it, do not set if deviation > a certain percentage
 
-        IPriceFeed(priceFeedAddress).setAnswer(_ts, _answer);
+        IPriceFeed(priceFeedAddress).setAnswer(_token, _ts, _answer);
     }
 
     function setLatestPrices(address[] calldata _tokens, uint256[] calldata _tses, uint256[] calldata _answers) external override {

--- a/contracts/core/PriceManager.sol
+++ b/contracts/core/PriceManager.sol
@@ -70,21 +70,25 @@ contract PriceManager is IPriceManager, Ownable, Constants {
         return (price * PRICE_PRECISION) / (10 ** _priceDecimals);
     }
 
-    function setPrice(address _token, uint256 _answer) public {
+    function setPrice(address _token, uint256 _ts, uint256 _answer) public {
         require(operators.getOperatorLevel(msg.sender) >= uint8(1), "Invalid operator");
         address priceFeedAddress = priceFeeds[_token];
         require(priceFeedAddress != address(0), "VaultPriceFeed: invalid price feed");
 
         // TODO: verify the price against pyth oracle before setting it, do not set if deviation > a certain percentage
 
-        IPriceFeed(priceFeedAddress).setLatestAnswer(_answer);
+        IPriceFeed(priceFeedAddress).setAnswer(_ts, _answer);
     }
 
-    function setLatestPrices(address[] calldata _tokens, uint256[] calldata _answers) external override {
+    function setLatestPrices(address[] calldata _tokens, uint256[] calldata _tses, uint256[] calldata _answers) external override {
         require(_tokens.length == _answers.length, "VaultPriceFeed: length mismatch");
 
         for (uint256 i = 0; i < _tokens.length; ++i) {
-            setPrice(_tokens[i], _answers[i]);
+            setPrice(_tokens[i], _tses[i], _answers[i]);
         }
+    }
+
+    function now() external view returns(uint256){
+        return block.timestamp;
     }
 }

--- a/contracts/core/interfaces/IPriceManager.sol
+++ b/contracts/core/interfaces/IPriceManager.sol
@@ -13,5 +13,5 @@ interface IPriceManager {
 
     function tokenToUsd(address _token, uint256 _tokenAmount) external view returns (uint256);
 
-    function setLatestPrices(address[] calldata _tokens, uint256[] calldata _answers) external;
+    function setLatestPrices(address[] calldata _tokens, uint256[] calldata _tses, uint256[] calldata _answers) external;
 }

--- a/contracts/oracle/FastPriceFeed.sol
+++ b/contracts/oracle/FastPriceFeed.sol
@@ -6,19 +6,19 @@ import "./interfaces/IPriceFeed.sol";
 
 contract FastPriceFeed is IPriceFeed {
     address public gov;
-    uint256 public ts;
-    uint256 public answer;
+    mapping(address=>uint256) public ts;
+    mapping(address=>uint256) public answer;
     string public override description = "FastPriceFeed";
     uint256 public decimals;
-    uint80 public roundId;
+    mapping(address=>uint80) public roundId;
 
-    mapping(uint80 => uint256) public answers;
-    mapping(uint80 => uint256) public latestAts;
+    mapping(address=>mapping(uint80 => uint256)) public answers;
+    mapping(address=>mapping(uint80 => uint256)) public latestAts;
     mapping(address => bool) public isAdmin;
 
     event SetAdmin(address indexed account, bool isAdmin);
     event SetDecription(string description);
-    event SetAnswer(uint256 ts, uint256 answer);
+    event SetAnswer(address token, uint256 ts, uint256 answer);
 
     constructor() {
         gov = msg.sender;
@@ -37,32 +37,32 @@ contract FastPriceFeed is IPriceFeed {
         emit SetDecription(_description);
     }
 
-    function setAnswer(uint256 _ts, uint256 _answer) public override {
+    function setAnswer(address _token, uint256 _ts, uint256 _answer) public override {
         require(isAdmin[msg.sender], "PriceFeed: forbidden");
-        if(_ts >= ts) {
-            roundId = roundId + 1;
-            answer = _answer;
-            ts = _ts;
-            answers[roundId] = _answer;
-            latestAts[roundId] = _ts;
-            emit SetAnswer(_ts, _answer);
+        if(_ts >= ts[_token]) {
+            uint80 r = ++roundId[_token];
+            answer[_token] = _answer;
+            ts[_token] = _ts;
+            answers[_token][r] = _answer;
+            latestAts[_token][r] = _ts;
+            emit SetAnswer(_token, _ts, _answer);
         }
     }
 
-    function setLatestAnswer(uint256 _answer) external {
-        setAnswer(block.timestamp, _answer);
+    function setLatestAnswer(address _token, uint256 _answer) external {
+        setAnswer(_token, block.timestamp, _answer);
     }
 
-    function latestAnswer() external view override returns (uint256) {
-        return answer;
+    function latestAnswer(address _token) external view override returns (uint256) {
+        return answer[_token];
     }
 
-    function latestRound() external view override returns (uint80) {
-        return roundId;
+    function latestRound(address _token) external view override returns (uint80) {
+        return roundId[_token];
     }
 
     // returns roundId, answer, startedAt, updatedAt, answeredInRound
-    function getRoundData(uint80 _roundId) external view override returns (uint80, uint256, uint256, uint256, uint80) {
-        return (_roundId, answers[_roundId], latestAts[roundId], 0, 0);
+    function getRoundData(address _token, uint80 _roundId) external view override returns (uint80, uint256, uint256, uint256, uint80) {
+        return (_roundId, answers[_token][_roundId], latestAts[_token][_roundId], 0, 0);
     }
 }

--- a/contracts/oracle/FastPriceFeed.sol
+++ b/contracts/oracle/FastPriceFeed.sol
@@ -6,7 +6,7 @@ import "./interfaces/IPriceFeed.sol";
 
 contract FastPriceFeed is IPriceFeed {
     address public gov;
-    address public override aggregator;
+    uint256 public ts;
     uint256 public answer;
     string public override description = "FastPriceFeed";
     uint256 public decimals;
@@ -18,7 +18,7 @@ contract FastPriceFeed is IPriceFeed {
 
     event SetAdmin(address indexed account, bool isAdmin);
     event SetDecription(string description);
-    event SetLatestAnswer(uint256 answer);
+    event SetAnswer(uint256 ts, uint256 answer);
 
     constructor() {
         gov = msg.sender;
@@ -37,13 +37,20 @@ contract FastPriceFeed is IPriceFeed {
         emit SetDecription(_description);
     }
 
-    function setLatestAnswer(uint256 _answer) external override {
+    function setAnswer(uint256 _ts, uint256 _answer) public override {
         require(isAdmin[msg.sender], "PriceFeed: forbidden");
-        roundId = roundId + 1;
-        answer = _answer;
-        answers[roundId] = _answer;
-        latestAts[roundId] = block.timestamp;
-        emit SetLatestAnswer(_answer);
+        if(_ts >= ts) {
+            roundId = roundId + 1;
+            answer = _answer;
+            ts = _ts;
+            answers[roundId] = _answer;
+            latestAts[roundId] = _ts;
+            emit SetAnswer(_ts, _answer);
+        }
+    }
+
+    function setLatestAnswer(uint256 _answer) external {
+        setAnswer(block.timestamp, _answer);
     }
 
     function latestAnswer() external view override returns (uint256) {

--- a/contracts/oracle/interfaces/IPriceFeed.sol
+++ b/contracts/oracle/interfaces/IPriceFeed.sol
@@ -5,11 +5,11 @@ pragma solidity 0.8.9;
 interface IPriceFeed {
     function description() external view returns (string memory);
 
-    function getRoundData(uint80 roundId) external view returns (uint80, uint256, uint256, uint256, uint80);
+    function getRoundData(address token, uint80 roundId) external view returns (uint80, uint256, uint256, uint256, uint80);
 
-    function latestAnswer() external view returns (uint256);
+    function latestAnswer(address token) external view returns (uint256);
 
-    function latestRound() external view returns (uint80);
+    function latestRound(address token) external view returns (uint80);
 
-    function setAnswer(uint256 _ts, uint256 _answer) external;
+    function setAnswer(address token, uint256 _ts, uint256 _answer) external;
 }

--- a/contracts/oracle/interfaces/IPriceFeed.sol
+++ b/contracts/oracle/interfaces/IPriceFeed.sol
@@ -3,8 +3,6 @@
 pragma solidity 0.8.9;
 
 interface IPriceFeed {
-    function aggregator() external view returns (address);
-
     function description() external view returns (string memory);
 
     function getRoundData(uint80 roundId) external view returns (uint80, uint256, uint256, uint256, uint80);
@@ -13,5 +11,5 @@ interface IPriceFeed {
 
     function latestRound() external view returns (uint80);
 
-    function setLatestAnswer(uint256 _answer) external;
+    function setAnswer(uint256 _ts, uint256 _answer) external;
 }

--- a/test/core/PriceManager.js
+++ b/test/core/PriceManager.js
@@ -26,42 +26,21 @@ describe('PriceManager', function () {
   let usdc
   let usdt
   let operator
-  let btcPriceFeed
-  let ethPriceFeed
-  let dogePriceFeed
-  let gbpPriceFeed
-  let eurPriceFeed
-  let jpyPriceFeed
-  let usdcPriceFeed
-  let usdtPriceFeed
+  let priceFeed
   let vlpPriceFeed
   let cooldownDuration
   let feeRewardBasisPoints // FeeRewardBasisPoints 70%
 
   before(async function () {
+    priceFeed = await deployContract('FastPriceFeed', [])
     btc = await deployContract('BaseToken', ['Bitcoin', 'BTC', 0])
-    btcPriceFeed = await deployContract('FastPriceFeed', [])
-
     eth = await deployContract('BaseToken', ['Ethereum', 'ETH', 0])
-    ethPriceFeed = await deployContract('FastPriceFeed', [])
-
     doge = await deployContract('BaseToken', ['Dogecoin', 'DOGE', 0])
-    dogePriceFeed = await deployContract('FastPriceFeed', [])
-
     gbp = await deployContract('BaseToken', ['Pound Sterling', 'GBP', 0])
-    gbpPriceFeed = await deployContract('FastPriceFeed', [])
-
     eur = await deployContract('BaseToken', ['Euro', 'EUR', 0])
-    eurPriceFeed = await deployContract('FastPriceFeed', [])
-
     jpy = await deployContract('BaseToken', ['Japanese Yan', 'JPY', 0])
-    jpyPriceFeed = await deployContract('FastPriceFeed', [])
-
     usdt = await deployContract('BaseToken', ['Tether USD', 'USDT', expandDecimals('10000000', 18)])
-    usdtPriceFeed = await deployContract('FastPriceFeed', [])
-
     usdc = await deployContract('BaseToken', ['USD Coin', 'USDC', expandDecimals('10000000', 18)])
-    usdcPriceFeed = await deployContract('FastPriceFeed', [])
     vlpPriceFeed = await deployContract('FastPriceFeed', [])
     vusd = await deployContract('VUSD', ['Vested USD', 'VUSD', 0])
     vlp = await deployContract('VLP', [])
@@ -81,33 +60,33 @@ describe('PriceManager', function () {
       operator.address, // operator
     ])
     //================= PriceFeed Prices Initialization ==================
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice(60000))
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice(56300))
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice(57000))
-    await ethPriceFeed.setLatestAnswer(toChainlinkPrice(4000))
-    await ethPriceFeed.setLatestAnswer(toChainlinkPrice(3920))
-    await ethPriceFeed.setLatestAnswer(toChainlinkPrice(4180))
-    await dogePriceFeed.setLatestAnswer(toChainlinkPrice(5))
-    await gbpPriceFeed.setLatestAnswer(toChainlinkPrice(15))
-    await eurPriceFeed.setLatestAnswer(toChainlinkPrice(1))
-    await jpyPriceFeed.setLatestAnswer('1600000') // 0.016
-    await usdtPriceFeed.setLatestAnswer(toChainlinkPrice(1))
-    await usdcPriceFeed.setLatestAnswer(toChainlinkPrice(1))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice(60000))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice(56300))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice(57000))
+    await priceFeed.setLatestAnswer(eth.address, toChainlinkPrice(4000))
+    await priceFeed.setLatestAnswer(eth.address, toChainlinkPrice(3920))
+    await priceFeed.setLatestAnswer(eth.address, toChainlinkPrice(4180))
+    await priceFeed.setLatestAnswer(doge.address, toChainlinkPrice(5))
+    await priceFeed.setLatestAnswer(gbp.address, toChainlinkPrice(15))
+    await priceFeed.setLatestAnswer(eur.address, toChainlinkPrice(1))
+    await priceFeed.setLatestAnswer(jpy.address, '1600000') // 0.016
+    await priceFeed.setLatestAnswer(usdt.address, toChainlinkPrice(1))
+    await priceFeed.setLatestAnswer(usdc.address, toChainlinkPrice(1))
 
     const cryptoMaxLeverage = 100 * 10000
     const forexMaxLeverage = 100 * 10000
-    await expect(priceManager.setTokenConfig(zeroAddress, 18, cryptoMaxLeverage, btcPriceFeed.address, 8)).to.be.revertedWith('Address is wrong')
-    await expect(priceManager.setTokenConfig(btc.address, 18, 1, btcPriceFeed.address, 8)).to.be.revertedWith(
+    await expect(priceManager.setTokenConfig(zeroAddress, 18, cryptoMaxLeverage, priceFeed.address, 8)).to.be.revertedWith('Address is wrong')
+    await expect(priceManager.setTokenConfig(btc.address, 18, 1, priceFeed.address, 8)).to.be.revertedWith(
       'Max Leverage should be greater than Min Leverage'
     )
-    await priceManager.setTokenConfig(btc.address, 18, cryptoMaxLeverage, btcPriceFeed.address, 8)
-    await priceManager.setTokenConfig(eth.address, 18, cryptoMaxLeverage, ethPriceFeed.address, 8)
-    await priceManager.setTokenConfig(gbp.address, 18, forexMaxLeverage, gbpPriceFeed.address, 8)
-    await priceManager.setTokenConfig(eur.address, 18, forexMaxLeverage, eurPriceFeed.address, 8)
-    await priceManager.setTokenConfig(doge.address, 18, cryptoMaxLeverage, dogePriceFeed.address, 8)
-    await priceManager.setTokenConfig(jpy.address, 18, forexMaxLeverage, jpyPriceFeed.address, 8)
-    await priceManager.setTokenConfig(usdc.address, 18, cryptoMaxLeverage, usdcPriceFeed.address, 8)
-    await priceManager.setTokenConfig(usdt.address, 18, cryptoMaxLeverage, usdtPriceFeed.address, 8)
+    await priceManager.setTokenConfig(btc.address, 18, cryptoMaxLeverage, priceFeed.address, 8)
+    await priceManager.setTokenConfig(eth.address, 18, cryptoMaxLeverage, priceFeed.address, 8)
+    await priceManager.setTokenConfig(gbp.address, 18, forexMaxLeverage, priceFeed.address, 8)
+    await priceManager.setTokenConfig(eur.address, 18, forexMaxLeverage, priceFeed.address, 8)
+    await priceManager.setTokenConfig(doge.address, 18, cryptoMaxLeverage, priceFeed.address, 8)
+    await priceManager.setTokenConfig(jpy.address, 18, forexMaxLeverage, priceFeed.address, 8)
+    await priceManager.setTokenConfig(usdc.address, 18, cryptoMaxLeverage, priceFeed.address, 8)
+    await priceManager.setTokenConfig(usdt.address, 18, cryptoMaxLeverage, priceFeed.address, 8)
   })
 
   it('usdToToken 0', async () => {

--- a/test/core/TriggerOrderManager.js
+++ b/test/core/TriggerOrderManager.js
@@ -37,15 +37,7 @@ describe('TriggerOrderManager', function () {
   let jpy
   let usdc
   let usdt
-  let btcPriceFeed
-  let ethPriceFeed
-  let dogePriceFeed
-  let gbpPriceFeed
-  let eurPriceFeed
-  let jpyPriceFeed
-  let usdcPriceFeed
-  let usdtPriceFeed
-  let vlpPriceFeed
+  let priceFeed
   let cooldownDuration
 
   async function expectMarketOrderSuccess(token, price) {
@@ -62,31 +54,15 @@ describe('TriggerOrderManager', function () {
 
   before(async function () {
     positionManagerAddress = user1.address
-
+    priceFeed = await deployContract('FastPriceFeed', [])
     btc = await deployContract('BaseToken', ['Bitcoin', 'BTC', 0])
-    btcPriceFeed = await deployContract('FastPriceFeed', [])
-    
     eth = await deployContract('BaseToken', ['Ethereum', 'ETH', 0])
-    ethPriceFeed = await deployContract('FastPriceFeed', [])
-
     doge = await deployContract('BaseToken', ['Dogecoin', 'DOGE', 0])
-    dogePriceFeed = await deployContract('FastPriceFeed', [])
-
     gbp = await deployContract('BaseToken', ['Pound Sterling', 'GBP', 0])
-    gbpPriceFeed = await deployContract('FastPriceFeed', [])
-
     eur = await deployContract('BaseToken', ['Euro', 'EUR', 0])
-    eurPriceFeed = await deployContract('FastPriceFeed', [])
-
     jpy = await deployContract('BaseToken', ['Japanese Yan', 'JPY', 0])
-    jpyPriceFeed = await deployContract('FastPriceFeed', [])
-
     usdt = await deployContract('BaseToken', ['Tether USD', 'USDT', expandDecimals('10000000', 18)])
-    usdtPriceFeed = await deployContract('FastPriceFeed', [])
-
     usdc = await deployContract('BaseToken', ['USD Coin', 'USDC', expandDecimals('10000000', 18)])
-    usdcPriceFeed = await deployContract('FastPriceFeed', [])
-    vlpPriceFeed = await deployContract('FastPriceFeed', [])
     vusd = await deployContract('VUSD', ['Vested USD', 'VUSD', 0])
     vlp = await deployContract('VLP', [])
     operator = await deployContract('ExchangeOperators', [])
@@ -143,33 +119,26 @@ describe('TriggerOrderManager', function () {
       VaultUtils.address
     )
     //================= PriceFeed Prices Initialization ==================
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice(60000))
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice(56300))
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice(57000))
-    await ethPriceFeed.setLatestAnswer(toChainlinkPrice(4000))
-    await ethPriceFeed.setLatestAnswer(toChainlinkPrice(3920))
-    await ethPriceFeed.setLatestAnswer(toChainlinkPrice(4180))
-    await dogePriceFeed.setLatestAnswer(toChainlinkPrice(5))
-    await gbpPriceFeed.setLatestAnswer(toChainlinkPrice(15))
-    await eurPriceFeed.setLatestAnswer(toChainlinkPrice(1))
-    await jpyPriceFeed.setLatestAnswer('1600000') // 0.016
-    await usdtPriceFeed.setLatestAnswer(toChainlinkPrice(1))
-    await usdcPriceFeed.setLatestAnswer(toChainlinkPrice(1))
-    await vlpPriceFeed.setLatestAnswer(toChainlinkPrice(16))
-    await btcPriceFeed.setAdmin(priceManager.address, true)
-    await ethPriceFeed.setAdmin(priceManager.address, true)
-    await dogePriceFeed.setAdmin(priceManager.address, true)
-    await gbpPriceFeed.setAdmin(priceManager.address, true)
-    await eurPriceFeed.setAdmin(priceManager.address, true)
-    await jpyPriceFeed.setAdmin(priceManager.address, true)
-    
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice(60000))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice(56300))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice(57000))
+    await priceFeed.setLatestAnswer(eth.address, toChainlinkPrice(4000))
+    await priceFeed.setLatestAnswer(eth.address, toChainlinkPrice(3920))
+    await priceFeed.setLatestAnswer(eth.address, toChainlinkPrice(4180))
+    await priceFeed.setLatestAnswer(doge.address, toChainlinkPrice(5))
+    await priceFeed.setLatestAnswer(gbp.address, toChainlinkPrice(15))
+    await priceFeed.setLatestAnswer(eur.address, toChainlinkPrice(1))
+    await priceFeed.setLatestAnswer(jpy.address, '1600000') // 0.016
+    await priceFeed.setLatestAnswer(usdt.address, toChainlinkPrice(1))
+    await priceFeed.setLatestAnswer(usdc.address, toChainlinkPrice(1))
+    await priceFeed.setAdmin(priceManager.address, true)
     const tokens = [
       {
         name: 'btc',
         address: btc.address,
         decimals: 18,
         isForex: false,
-        priceFeed: btcPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 30 * 10000,
         marginFeeBasisPoints: 80, // 0.08% 80 / 100000
@@ -179,7 +148,7 @@ describe('TriggerOrderManager', function () {
         address: eth.address,
         decimals: 18,
         isForex: false,
-        priceFeed: ethPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 30 * 10000,
         marginFeeBasisPoints: 80, // 0.08% 80 / 100000
@@ -189,7 +158,7 @@ describe('TriggerOrderManager', function () {
         address: doge.address,
         decimals: 18,
         isForex: false,
-        priceFeed: dogePriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 30 * 10000,
         marginFeeBasisPoints: 80, // 0.08% 80 / 100000
@@ -199,7 +168,7 @@ describe('TriggerOrderManager', function () {
         address: gbp.address,
         decimals: 18,
         isForex: true,
-        priceFeed: gbpPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 100 * 10000,
         marginFeeBasisPoints: 8, // 0.008% 80 / 100000
@@ -209,7 +178,7 @@ describe('TriggerOrderManager', function () {
         address: eur.address,
         decimals: 18,
         isForex: true,
-        priceFeed: eurPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 100 * 10000,
         marginFeeBasisPoints: 8, // 0.008% 80 / 100000
@@ -219,7 +188,7 @@ describe('TriggerOrderManager', function () {
         address: jpy.address,
         decimals: 18,
         isForex: true,
-        priceFeed: jpyPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 100 * 10000,
         marginFeeBasisPoints: 8, // 0.008% 80 / 100000
@@ -229,7 +198,7 @@ describe('TriggerOrderManager', function () {
         address: usdc.address,
         decimals: 18,
         isForex: true,
-        priceFeed: usdcPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 100 * 10000,
         marginFeeBasisPoints: 80, // 0.08% 80 / 100000
@@ -239,7 +208,7 @@ describe('TriggerOrderManager', function () {
         address: usdt.address,
         decimals: 18,
         isForex: true,
-        priceFeed: usdtPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 100 * 10000,
         marginFeeBasisPoints: 80, // 0.08% 80 / 100000
@@ -403,7 +372,7 @@ describe('TriggerOrderManager', function () {
 
   it('setLatestAnswer for BTC', async () => {
     const lastBtcPrice = await priceManager.getLastPrice(btc.address)
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice('57002'))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice('57002'))
   })
 
   it('addTriggerOrders 1', async () => {
@@ -454,7 +423,7 @@ describe('TriggerOrderManager', function () {
   })
 
   it('setLatestAnswer for BTC', async () => {
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice('58000'))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice('58000'))
   })
 
   it('triggerPosition 1', async () => {
@@ -474,11 +443,7 @@ describe('TriggerOrderManager', function () {
   })
 
   it('setLatestAnswer for BTC', async () => {
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice('58500'))
-  })
-
-  it('setLatestAnswer for BTC', async () => {
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice('57000'))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice('57000'))
   })
 
   it('increasePosition for StopLoss', async () => {
@@ -528,7 +493,7 @@ describe('TriggerOrderManager', function () {
   })
 
   it('setLatestAnswer for BTC', async () => {
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice('52000'))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice('52000'))
   })
 
   it('triggerPosition 4', async () => {
@@ -548,7 +513,7 @@ describe('TriggerOrderManager', function () {
   })
 
   it('setLatestAnswer for BTC', async () => {
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice('57000'))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice('57000'))
   })
 
   // note: this test is completely duplicated from another test in this file
@@ -616,7 +581,7 @@ describe('TriggerOrderManager', function () {
   })
 
   it('setLatestAnswer for BTC', async () => {
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice('58500'))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice('58500'))
   })
 
   it('triggerPosition 5', async () => {
@@ -644,7 +609,7 @@ describe('TriggerOrderManager', function () {
   })
 
   it('setLatestAnswer for BTC', async () => {
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice('57000'))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice('57000'))
   })
 
   it('addTriggerOrdersData with wrong orders or invalid data for Long', async () => {
@@ -718,7 +683,7 @@ describe('TriggerOrderManager', function () {
   })
 
   it('setLatestAnswer for BTC', async () => {
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice('57000'))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice('57000'))
   })
 
   it('increasePosition for Short', async () => {
@@ -813,7 +778,7 @@ describe('TriggerOrderManager', function () {
     await expect(PositionVault.triggerForTPSL(account, pId)).to.be.revertedWith('trigger not ready')
   })
   it('setLatestAnswer for BTC', async () => {
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice('56200'))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice('56200'))
   })
 
   it('validateTPSL for Short after rising price', async () => {

--- a/test/core/TriggerOrderManager.js
+++ b/test/core/TriggerOrderManager.js
@@ -48,6 +48,18 @@ describe('TriggerOrderManager', function () {
   let vlpPriceFeed
   let cooldownDuration
 
+  async function expectMarketOrderSuccess(token, price) {
+    expect(await PositionVault.getNumOfUnexecutedMarketOrders()).eq(1)
+    const now = await priceManager.now()
+    await priceManager.setPrice(token.address, now, toChainlinkPrice(price))
+    const tx = await PositionVault.connect(user1).executeOpenMarketOrders(
+      1,
+    )
+    const receipt = await tx.wait()
+    const errorEvent = receipt.events.find((event) => event.event === 'MarketOrderExecutionError')
+    expect(errorEvent).to.be.undefined
+  }
+
   before(async function () {
     positionManagerAddress = user1.address
 
@@ -383,7 +395,7 @@ describe('TriggerOrderManager', function () {
       triggerPrices, //triggerPrices
       referAddress
     )
-    await PositionVault.connect(user1).executeOpenMarketOrdersWithPrices(1, [btc.address], [toChainlinkPrice('57000')])
+    await expectMarketOrderSuccess(btc, '57000')
     const passTime = 60 * 60 * 24
     await ethers.provider.send('evm_increaseTime', [passTime])
     await ethers.provider.send('evm_mine')
@@ -488,7 +500,7 @@ describe('TriggerOrderManager', function () {
       triggerPrices, //triggerPrices
       referAddress
     )
-    await PositionVault.connect(user1).executeOpenMarketOrdersWithPrices(1, [indexToken], [toChainlinkPrice('57000')])
+    await expectMarketOrderSuccess(btc, '57000')
     const passTime = 60 * 60 * 24
     await ethers.provider.send('evm_increaseTime', [passTime])
     await ethers.provider.send('evm_mine')
@@ -560,7 +572,7 @@ describe('TriggerOrderManager', function () {
       triggerPrices, //triggerPrices
       referAddress
     )
-    await PositionVault.connect(user1).executeOpenMarketOrdersWithPrices(1, [indexToken], [toChainlinkPrice('57000')])
+    await expectMarketOrderSuccess(btc, '57000')
 
     const passTime = 60 * 60 * 24
     await ethers.provider.send('evm_increaseTime', [passTime])
@@ -728,7 +740,7 @@ describe('TriggerOrderManager', function () {
       triggerPrices, //triggerPrices
       referAddress
     )
-    await PositionVault.connect(user1).executeOpenMarketOrdersWithPrices(1, [indexToken], [toChainlinkPrice('57000')])
+    await expectMarketOrderSuccess(btc, '57000')
   })
 
   it('addTriggerOrdersData with wrong orders or invalid for Short', async () => {

--- a/test/core/Vault.js
+++ b/test/core/Vault.js
@@ -48,18 +48,18 @@ describe('Vault', function () {
 
   let BASIS_POINTS_DIVISOR
   let PRICE_PRECISION
-  let btcPriceFeed
-  let ethPriceFeed
-  let dogePriceFeed
-  let gbpPriceFeed
-  let eurPriceFeed
-  let jpyPriceFeed
-  let usdcPriceFeed
+  let priceFeed
   let vaultPriceFeed
   let cooldownDuration
   let feeRewardBasisPoints // FeeRewardBasisPoints 70%
 
   let snapshot
+
+  let btcPriceFeed = { // mock object
+    setLatestAnswer: async function(price){
+      await priceFeed.setLatestAnswer(btc.address, price)
+    }
+  }
 
   before(async function () {
     trustForwarder = user3.address
@@ -91,33 +91,15 @@ describe('Vault', function () {
     operator.setOperator(PositionVault.address, 1)
     priceManager = await deployContract('PriceManager', [operator.address])
 
+    priceFeed = await deployContract('FastPriceFeed', [])
+    await priceFeed.setAdmin(priceManager.address, true)
     btc = await deployContract('BaseToken', ['Bitcoin', 'BTC', expandDecimals('10', 18)])
-    btcPriceFeed = await deployContract('FastPriceFeed', [])
-    await btcPriceFeed.setAdmin(priceManager.address, true)
-
     eth = await deployContract('BaseToken', ['Ethereum', 'ETH', 0])
-    ethPriceFeed = await deployContract('FastPriceFeed', [])
-    await ethPriceFeed.setAdmin(priceManager.address, true)
-
     doge = await deployContract('BaseToken', ['Dogecoin', 'DOGE', 0])
-    dogePriceFeed = await deployContract('FastPriceFeed', [])
-    await dogePriceFeed.setAdmin(priceManager.address, true)
-
     gbp = await deployContract('BaseToken', ['Pound Sterling', 'GBP', 0])
-    gbpPriceFeed = await deployContract('FastPriceFeed', [])
-    await gbpPriceFeed.setAdmin(priceManager.address, true)
-
     eur = await deployContract('BaseToken', ['Euro', 'EUR', 0])
-    eurPriceFeed = await deployContract('FastPriceFeed', [])
-    await eurPriceFeed.setAdmin(priceManager.address, true)
-
     jpy = await deployContract('BaseToken', ['Japanese Yan', 'JPY', 0])
-    jpyPriceFeed = await deployContract('FastPriceFeed', [])
-    await jpyPriceFeed.setAdmin(priceManager.address, true)
-
     usdc = await deployContract('BaseToken', ['USD Coin', 'USDC', expandDecimals('10000000', 18)])
-    usdcPriceFeed = await deployContract('FastPriceFeed', [])
-    await usdcPriceFeed.setAdmin(priceManager.address, true)
 
     await expect(
       deployContract('SettingsManager', [zeroAddress, operator.address, vusd.address, tokenFarm.address])
@@ -212,24 +194,25 @@ describe('Vault', function () {
       VaultUtils.address
     )
     //================= PriceFeed Prices Initialization ==================
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice(60000))
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice(56300))
-    await btcPriceFeed.setLatestAnswer(toChainlinkPrice(57000))
-    await ethPriceFeed.setLatestAnswer(toChainlinkPrice(4000))
-    await ethPriceFeed.setLatestAnswer(toChainlinkPrice(3920))
-    await ethPriceFeed.setLatestAnswer(toChainlinkPrice(4180))
-    await dogePriceFeed.setLatestAnswer(toChainlinkPrice(5))
-    await gbpPriceFeed.setLatestAnswer(toChainlinkPrice(15))
-    await eurPriceFeed.setLatestAnswer(toChainlinkPrice(1))
-    await jpyPriceFeed.setLatestAnswer('1600000') // 0.016
-    await usdcPriceFeed.setLatestAnswer(toChainlinkPrice(1))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice(60000))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice(56300))
+    await priceFeed.setLatestAnswer(btc.address, toChainlinkPrice(57000))
+    await priceFeed.setLatestAnswer(eth.address, toChainlinkPrice(4000))
+    await priceFeed.setLatestAnswer(eth.address, toChainlinkPrice(3920))
+    await priceFeed.setLatestAnswer(eth.address, toChainlinkPrice(4180))
+    await priceFeed.setLatestAnswer(doge.address, toChainlinkPrice(5))
+    await priceFeed.setLatestAnswer(gbp.address, toChainlinkPrice(15))
+    await priceFeed.setLatestAnswer(eur.address, toChainlinkPrice(1))
+    await priceFeed.setLatestAnswer(jpy.address, '1600000') // 0.016
+    await priceFeed.setLatestAnswer(usdc.address, toChainlinkPrice(1))
+    await priceFeed.setAdmin(priceManager.address, true)
     const tokens = [
       {
         name: 'btc',
         address: btc.address,
         decimals: 18,
         isForex: false,
-        priceFeed: btcPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 30 * 10000,
         marginFeeBasisPoints: 80, // 0.08% 80 / 100000
@@ -239,7 +222,7 @@ describe('Vault', function () {
         address: eth.address,
         decimals: 18,
         isForex: false,
-        priceFeed: ethPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 30 * 10000,
         marginFeeBasisPoints: 80, // 0.08% 80 / 100000
@@ -249,7 +232,7 @@ describe('Vault', function () {
         address: doge.address,
         decimals: 18,
         isForex: false,
-        priceFeed: dogePriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 30 * 10000,
         marginFeeBasisPoints: 80, // 0.08% 80 / 100000
@@ -259,7 +242,7 @@ describe('Vault', function () {
         address: gbp.address,
         decimals: 18,
         isForex: true,
-        priceFeed: gbpPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 100 * 10000,
         marginFeeBasisPoints: 8, // 0.008% 80 / 100000
@@ -269,7 +252,7 @@ describe('Vault', function () {
         address: eur.address,
         decimals: 18,
         isForex: true,
-        priceFeed: eurPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 100 * 10000,
         marginFeeBasisPoints: 8, // 0.008% 80 / 100000
@@ -279,7 +262,7 @@ describe('Vault', function () {
         address: jpy.address,
         decimals: 18,
         isForex: true,
-        priceFeed: jpyPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 100 * 10000,
         marginFeeBasisPoints: 8, // 0.008% 80 / 100000
@@ -289,7 +272,7 @@ describe('Vault', function () {
         address: usdc.address,
         decimals: 18,
         isForex: true,
-        priceFeed: usdcPriceFeed.address,
+        priceFeed: priceFeed.address,
         priceDecimals: 8,
         maxLeverage: 100 * 10000,
         marginFeeBasisPoints: 80, // 0.08% 80 / 100000

--- a/test/oracle/fastPriceFeed.js
+++ b/test/oracle/fastPriceFeed.js
@@ -15,10 +15,12 @@ use(solidity)
 describe('FastPriceFeed', function () {
   const provider = waffle.provider
   const [wallet, user0, user1, user2, user3] = provider.getWallets()
+  let btc
   let btcPriceFeed
   let latestAt
 
   before(async function () {
+    btc = await deployContract('BaseToken', ['Bitcoin', 'BTC', 0])
     btcPriceFeed = await deployContract('FastPriceFeed', [])
   })
 
@@ -35,18 +37,18 @@ describe('FastPriceFeed', function () {
   })
 
   it('setLatestAnswer', async () => {
-    await expect(btcPriceFeed.connect(user0).setLatestAnswer(toChainlinkPrice(60000))).to.be.revertedWith(
+    await expect(btcPriceFeed.connect(user0).setLatestAnswer(btc.address, toChainlinkPrice(60000))).to.be.revertedWith(
       'PriceFeed: forbidden'
     )
-    await btcPriceFeed.connect(user1).setLatestAnswer(toChainlinkPrice(60000))
-    const answer = await btcPriceFeed.latestAnswer()
+    await btcPriceFeed.connect(user1).setLatestAnswer(btc.address, toChainlinkPrice(60000))
+    const answer = await btcPriceFeed.latestAnswer(btc.address)
     latestAt = await getBlockTime(provider)
     expect(parseFloat(ethers.utils.formatUnits(answer, 8))).eq(60000)
   })
 
   it('getRoundData', async () => {
     const roundId = 1
-    const roundData = await btcPriceFeed.getRoundData(roundId)
+    const roundData = await btcPriceFeed.getRoundData(btc.address, roundId)
     const answer = roundData[1]
     const roundLatestAt = roundData[2]
     expect(answer).eq(toChainlinkPrice(60000))
@@ -54,6 +56,6 @@ describe('FastPriceFeed', function () {
   })
 
   it('latestRound', async () => {
-    expect(await btcPriceFeed.latestRound()).eq(1)
+    expect(await btcPriceFeed.latestRound(btc.address)).eq(1)
   })
 })

--- a/test/oracle/fastPriceFeed.js
+++ b/test/oracle/fastPriceFeed.js
@@ -53,10 +53,6 @@ describe('FastPriceFeed', function () {
     expect(roundLatestAt).eq(latestAt)
   })
 
-  it('aggregator', async () => {
-    expect(await btcPriceFeed.aggregator()).eq(zeroAddress)
-  })
-
   it('latestRound', async () => {
     expect(await btcPriceFeed.latestRound()).eq(1)
   })

--- a/test/tokens/VLP.js
+++ b/test/tokens/VLP.js
@@ -33,7 +33,7 @@ describe("VLP", function () {
             operator.address
         ]);
         let usdcPriceFeed = await deployContract("FastPriceFeed", [])
-        await usdcPriceFeed.setLatestAnswer(toChainlinkPrice(1))
+        await usdcPriceFeed.setLatestAnswer(usdc.address, toChainlinkPrice(1))
         await priceManager.setTokenConfig(usdc.address, 6, 100 * 10000, usdcPriceFeed.address, 8);
         let vestingDuration = 6 * 30 * 24 * 60 * 60
         let PositionVault = await deployContract("PositionVault", []);


### PR DESCRIPTION
this also remove executeOpenMarketOrdersWithPrice, the trigger bot will directly call PriceManager, no need to let PositionVault to update price